### PR TITLE
Fix broken JSDocs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DocumentDB’s language integrated, transactional execution of JavaScript suppor
 
 * Official documentation can be found the [Azure website](http://azure.microsoft.com/en-us/documentation/articles/documentdb-programming/)
 
-* JSDocs for the Server-Side JavaScript SDK can be found [here](http://azure.github.io/azure-documentdb-js-server/)
+* JSDocs for the Server-Side JavaScript SDK can be found [here](https://azure.github.io/azure-cosmosdb-js-server/)
 
 * .NET sample code for creating and executing a sproc can be found on our [.NET GitHub repo](https://github.com/Azure/azure-documentdb-net/tree/master/samples/code-samples/ServerSideScripts).
 


### PR DESCRIPTION
The link was broken, I only found the new one by chance...
BTW, those docs are *very* hard to find, even without the broken link.