### PR TITLE
Fixed invalid links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ DocumentDB’s language integrated, transactional execution of JavaScript suppor
 
 ## Documentation
 
-* Official documentation can be found the [Azure website](http://azure.microsoft.com/en-us/documentation/articles/documentdb-programming/)
+* Official documentation can be found the [Azure website](https://docs.microsoft.com/en-us/azure/cosmos-db/stored-procedures-triggers-udfs)
 
 * JSDocs for the Server-Side JavaScript SDK can be found [here](https://azure.github.io/azure-cosmosdb-js-server/)
 
-* .NET sample code for creating and executing a sproc can be found on our [.NET GitHub repo](https://github.com/Azure/azure-documentdb-net/tree/master/samples/code-samples/ServerSideScripts).
+* .NET sample code for creating and executing a sproc can be found on our [.NET GitHub repo](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/Usage/ServerSideScripts).
 
-* Node.js sample code for creating and executing a sproc can be found on our [Node.js GitHub repo](https://github.com/Azure/azure-documentdb-node/tree/master/samples/ServerSideScripts).
+* Node.js sample code for creating and executing a sproc can be found on our [Node.js GitHub repo](https://github.com/Azure/azure-cosmosdb-node/tree/master/samples/ServerSideScripts).
 
 ## Videos
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,5 +1,0 @@
-**Documentation:** http://azure.microsoft.com/en-us/documentation/articles/documentdb-programming/
-
-Node.js sample code for creating and executing a sproc can be found on our [Node.js GitHub repo](https://github.com/Azure/azure-documentdb-node/tree/master/samples/DocumentDB.Samples.ServerSideScripts).
-
-**Want to share your awesome stored procedure?** Please, send us a pull-request! We’d love to feature and spotlight you on our Github and [Twitter](https://twitter.com/documentdb) accounts.


### PR DESCRIPTION
- Fixed broken and old links
- Removed readme from `./samples`, since it was a small, unmaintained copy of the readme in the root.